### PR TITLE
Changing base image from alpine:3.5 to alpine:3.6

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 MAINTAINER NGINX Docker Maintainers "docker-maint@nginx.com"
 


### PR DESCRIPTION
Due to security vulnerabilities in 3.5 (zlib)